### PR TITLE
fix(agent-rules): a directory-content probe that failed on large directories

### DIFF
--- a/skills/agent-rules/scripts/detect-project.sh
+++ b/skills/agent-rules/scripts/detect-project.sh
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck disable=SC1091  # pre-commit runs shellcheck without -x, so
+# it cannot follow this source however the path is written.
 source "$SCRIPT_DIR/lib/config-root.sh"
 
 PROJECT_DIR="${1:-.}"

--- a/skills/agent-rules/scripts/extract-adrs.sh
+++ b/skills/agent-rules/scripts/extract-adrs.sh
@@ -96,6 +96,8 @@ for file in "${FILTERED_FILES[@]}"; do
                 # Skip empty lines
                 [[ -z "${sline// /}" ]] && continue
                 # Extract the status value
+                # shellcheck disable=SC2016  # sed script: the backticks and
+                # asterisks are literal regex, not shell expansions.
                 sline=$(echo "$sline" | sed -E 's/^\*\*//;s/\*\*.*$//;s/^- //;s/^`//;s/`$//')
                 if [[ "$sline" =~ ^(Accepted|Proposed|Deprecated|Superseded|Rejected|Draft|Approved) ]]; then
                     status="${BASH_REMATCH[1]}"

--- a/skills/agent-rules/scripts/extract-ci-rules.sh
+++ b/skills/agent-rules/scripts/extract-ci-rules.sh
@@ -37,6 +37,9 @@ has_yq() { command -v yq &>/dev/null; }
 # ---------------------------------------------------------------------------
 # GitHub Actions parsing
 # ---------------------------------------------------------------------------
+# shellcheck disable=SC2034  # the arrays below are read by NAME through
+# collect_unique/arr_to_json, which take a nameref; shellcheck cannot follow
+# that and reports every one of them as unused.
 parse_github_actions() {
     local wf_dir=".github/workflows"
     [[ -d "$wf_dir" ]] || { echo "{}"; return; }
@@ -280,6 +283,9 @@ parse_github_actions() {
 # ---------------------------------------------------------------------------
 # GitLab CI parsing
 # ---------------------------------------------------------------------------
+# shellcheck disable=SC2034  # the arrays below are read by NAME through
+# collect_unique/arr_to_json, which take a nameref; shellcheck cannot follow
+# that and reports every one of them as unused.
 parse_gitlab_ci() {
     [[ -f ".gitlab-ci.yml" ]] || { echo "{}"; return; }
 
@@ -325,6 +331,9 @@ parse_gitlab_ci() {
 # ---------------------------------------------------------------------------
 # Concourse CI parsing
 # ---------------------------------------------------------------------------
+# shellcheck disable=SC2034  # the arrays below are read by NAME through
+# collect_unique/arr_to_json, which take a nameref; shellcheck cannot follow
+# that and reports every one of them as unused.
 parse_concourse() {
     local pipeline_file=""
     for f in ci/pipeline.yml ci/pipeline.yaml pipeline.yml pipeline.yaml ci/*.yml; do

--- a/skills/agent-rules/scripts/generate-file-map.sh
+++ b/skills/agent-rules/scripts/generate-file-map.sh
@@ -103,23 +103,23 @@ infer_purpose() {
     local dir="$1"
 
     # Check for specific file patterns
-    if ls "$dir"/*.go 2>/dev/null | head -1 > /dev/null; then
+    if compgen -G "$dir/*.go" > /dev/null; then
         echo "Go packages"
-    elif ls "$dir"/*.py 2>/dev/null | head -1 > /dev/null; then
+    elif compgen -G "$dir/*.py" > /dev/null; then
         echo "Python modules"
-    elif ls "$dir"/*.php 2>/dev/null | head -1 > /dev/null; then
+    elif compgen -G "$dir/*.php" > /dev/null; then
         echo "PHP classes"
-    elif ls "$dir"/*.ts 2>/dev/null | head -1 > /dev/null; then
+    elif compgen -G "$dir/*.ts" > /dev/null; then
         echo "TypeScript modules"
-    elif ls "$dir"/*.tsx 2>/dev/null | head -1 > /dev/null; then
+    elif compgen -G "$dir/*.tsx" > /dev/null; then
         echo "React components"
-    elif ls "$dir"/*.vue 2>/dev/null | head -1 > /dev/null; then
+    elif compgen -G "$dir/*.vue" > /dev/null; then
         echo "Vue components"
-    elif ls "$dir"/*.sh 2>/dev/null | head -1 > /dev/null; then
+    elif compgen -G "$dir/*.sh" > /dev/null; then
         echo "shell scripts"
-    elif ls "$dir"/*.md 2>/dev/null | head -1 > /dev/null; then
+    elif compgen -G "$dir/*.md" > /dev/null; then
         echo "documentation"
-    elif ls "$dir"/*.json 2>/dev/null | head -1 > /dev/null; then
+    elif compgen -G "$dir/*.json" > /dev/null; then
         echo "configuration/data"
     else
         echo "project files"

--- a/skills/agent-rules/scripts/lib/summary.sh
+++ b/skills/agent-rules/scripts/lib/summary.sh
@@ -5,6 +5,8 @@
 if [[ -t 1 ]]; then
     GREEN='\033[0;32m'
     YELLOW='\033[0;33m'
+    # shellcheck disable=SC2034  # part of the palette; kept so the colour and
+    # no-colour branches stay symmetric rather than losing one entry.
     BLUE='\033[0;34m'
     CYAN='\033[0;36m'
     GRAY='\033[0;90m'
@@ -13,6 +15,7 @@ if [[ -t 1 ]]; then
 else
     GREEN=''
     YELLOW=''
+    # shellcheck disable=SC2034  # see the palette comment above
     BLUE=''
     CYAN=''
     GRAY=''
@@ -21,6 +24,9 @@ else
 fi
 
 # Summary data storage
+# shellcheck disable=SC2034  # written by add_summary below and read by nothing
+# in this repository — the provenance it records has no consumer yet. Left in
+# place rather than deleted, but it buys no trust until something reads it.
 declare -A SUMMARY_SOURCES
 declare -a SUMMARY_RULES
 declare -a SUMMARY_WARNINGS
@@ -43,6 +49,7 @@ record_detection() {
     if [[ -n "$source_detail" ]]; then
         SUMMARY_SOURCES["$category"]="$value (from $source_file: $source_detail)"
     else
+        # shellcheck disable=SC2034  # see the declaration comment above
         SUMMARY_SOURCES["$category"]="$value (from $source_file)"
     fi
 }
@@ -84,14 +91,23 @@ print_summary() {
     echo -e "${CYAN}▸ Project Detection${NC}"
     echo -e "  ${GRAY}────────────────────────────────────────${NC}"
 
-    local lang=$(echo "$project_info" | jq -r '.language')
-    local version=$(echo "$project_info" | jq -r '.version')
-    local ptype=$(echo "$project_info" | jq -r '.type')
-    local framework=$(echo "$project_info" | jq -r '.framework')
-    local build_tool=$(echo "$project_info" | jq -r '.build_tool')
-    local test_fw=$(echo "$project_info" | jq -r '.test_framework')
-    local ci=$(echo "$project_info" | jq -r '.ci')
-    local docker=$(echo "$project_info" | jq -r '.has_docker')
+    local lang
+
+    lang=$(echo "$project_info" | jq -r '.language')
+    local version
+    version=$(echo "$project_info" | jq -r '.version')
+    local ptype
+    ptype=$(echo "$project_info" | jq -r '.type')
+    local framework
+    framework=$(echo "$project_info" | jq -r '.framework')
+    local build_tool
+    build_tool=$(echo "$project_info" | jq -r '.build_tool')
+    local test_fw
+    test_fw=$(echo "$project_info" | jq -r '.test_framework')
+    local ci
+    ci=$(echo "$project_info" | jq -r '.ci')
+    local docker
+    docker=$(echo "$project_info" | jq -r '.has_docker')
 
     # Determine source file
     local lang_source=""
@@ -112,7 +128,8 @@ print_summary() {
     [[ "$docker" == "true" ]] && printf "  %-16s %s\n" "Docker:" "yes"
 
     # Quality Tools
-    local tools=$(echo "$project_info" | jq -r '.quality_tools | join(", ")')
+    local tools
+    tools=$(echo "$project_info" | jq -r '.quality_tools | join(", ")')
     if [[ -n "$tools" && "$tools" != "" ]]; then
         echo ""
         echo -e "${CYAN}▸ Quality Tools Detected${NC}"
@@ -121,7 +138,8 @@ print_summary() {
     fi
 
     # IDE Configs (from ide_info)
-    local detected_ides=$(echo "$ide_info" | jq -r '.detected_ides | join(", ")' 2>/dev/null || echo "")
+    local detected_ides
+    detected_ides=$(echo "$ide_info" | jq -r '.detected_ides | join(", ")' 2>/dev/null || echo "")
     if [[ -n "$detected_ides" && "$detected_ides" != "" ]]; then
         echo ""
         echo -e "${CYAN}▸ IDE Configurations${NC}"
@@ -129,15 +147,18 @@ print_summary() {
         printf "  %s\n" "$detected_ides"
 
         # Show editorconfig details if present
-        local indent=$(echo "$ide_info" | jq -r '.editorconfig.indent_style // ""' 2>/dev/null || echo "")
+        local indent
+        indent=$(echo "$ide_info" | jq -r '.editorconfig.indent_style // ""' 2>/dev/null || echo "")
         if [[ -n "$indent" ]]; then
-            local indent_size=$(echo "$ide_info" | jq -r '.editorconfig.indent_size // ""' 2>/dev/null || echo "")
+            local indent_size
+            indent_size=$(echo "$ide_info" | jq -r '.editorconfig.indent_size // ""' 2>/dev/null || echo "")
             printf "  ${GRAY}→ indent: %s (%s)${NC}\n" "$indent" "$indent_size"
         fi
     fi
 
     # AI Agent Configs (from agent_info)
-    local detected_agents=$(echo "$agent_info" | jq -r '.detected_agents | join(", ")' 2>/dev/null || echo "")
+    local detected_agents
+    detected_agents=$(echo "$agent_info" | jq -r '.detected_agents | join(", ")' 2>/dev/null || echo "")
     if [[ -n "$detected_agents" && "$detected_agents" != "" ]]; then
         echo ""
         echo -e "${CYAN}▸ AI Agent Configurations${NC}"
@@ -146,10 +167,14 @@ print_summary() {
     fi
 
     # Documentation Files (from docs_info)
-    local has_contributing=$(echo "$docs_info" | jq -r '.contributing.file // ""' 2>/dev/null || echo "")
-    local has_security=$(echo "$docs_info" | jq -r '.security.file // ""' 2>/dev/null || echo "")
-    local has_changelog=$(echo "$docs_info" | jq -r '.changelog.file // ""' 2>/dev/null || echo "")
-    local has_coc=$(echo "$docs_info" | jq -r '.code_of_conduct.exists // false' 2>/dev/null || echo "false")
+    local has_contributing
+    has_contributing=$(echo "$docs_info" | jq -r '.contributing.file // ""' 2>/dev/null || echo "")
+    local has_security
+    has_security=$(echo "$docs_info" | jq -r '.security.file // ""' 2>/dev/null || echo "")
+    local has_changelog
+    has_changelog=$(echo "$docs_info" | jq -r '.changelog.file // ""' 2>/dev/null || echo "")
+    local has_coc
+    has_coc=$(echo "$docs_info" | jq -r '.code_of_conduct.exists // false' 2>/dev/null || echo "false")
 
     if [[ -n "$has_contributing" || -n "$has_security" || -n "$has_changelog" || "$has_coc" == "true" ]]; then
         echo ""
@@ -162,11 +187,15 @@ print_summary() {
     fi
 
     # Platform Files (from platform_info)
-    local platform=$(echo "$platform_info" | jq -r '.platform // "none"' 2>/dev/null || echo "none")
+    local platform
+    platform=$(echo "$platform_info" | jq -r '.platform // "none"' 2>/dev/null || echo "none")
     if [[ "$platform" != "none" ]]; then
-        local pr_template=$(echo "$platform_info" | jq -r '.pull_request.template_file // ""' 2>/dev/null || echo "")
-        local codeowners=$(echo "$platform_info" | jq -r '.codeowners.file // ""' 2>/dev/null || echo "")
-        local dependabot=$(echo "$platform_info" | jq -r '.dependency_updates.dependabot.file // ""' 2>/dev/null || echo "")
+        local pr_template
+        pr_template=$(echo "$platform_info" | jq -r '.pull_request.template_file // ""' 2>/dev/null || echo "")
+        local codeowners
+        codeowners=$(echo "$platform_info" | jq -r '.codeowners.file // ""' 2>/dev/null || echo "")
+        local dependabot
+        dependabot=$(echo "$platform_info" | jq -r '.dependency_updates.dependabot.file // ""' 2>/dev/null || echo "")
 
         if [[ -n "$pr_template" || -n "$codeowners" || -n "$dependabot" ]]; then
             echo ""
@@ -183,12 +212,19 @@ print_summary() {
     echo -e "${CYAN}▸ Commands Extracted${NC}"
     echo -e "  ${GRAY}────────────────────────────────────────${NC}"
 
-    local typecheck=$(echo "$commands_info" | jq -r '.typecheck')
-    local lint=$(echo "$commands_info" | jq -r '.lint')
-    local format=$(echo "$commands_info" | jq -r '.format')
-    local test_cmd=$(echo "$commands_info" | jq -r '.test')
-    local build=$(echo "$commands_info" | jq -r '.build')
-    local dev=$(echo "$commands_info" | jq -r '.dev')
+    local typecheck
+
+    typecheck=$(echo "$commands_info" | jq -r '.typecheck')
+    local lint
+    lint=$(echo "$commands_info" | jq -r '.lint')
+    local format
+    format=$(echo "$commands_info" | jq -r '.format')
+    local test_cmd
+    test_cmd=$(echo "$commands_info" | jq -r '.test')
+    local build
+    build=$(echo "$commands_info" | jq -r '.build')
+    local dev
+    dev=$(echo "$commands_info" | jq -r '.dev')
 
     [[ -n "$typecheck" && "$typecheck" != "" ]] && printf "  %-12s ${YELLOW}%s${NC}\n" "typecheck:" "$typecheck"
     [[ -n "$lint" && "$lint" != "" ]] && printf "  %-12s ${YELLOW}%s${NC}\n" "lint:" "$lint"
@@ -198,7 +234,8 @@ print_summary() {
     [[ -n "$dev" && "$dev" != "" ]] && printf "  %-12s ${YELLOW}%s${NC}\n" "dev:" "$dev"
 
     # Scopes Detected
-    local scope_count=$(echo "$scopes_info" | jq '.scopes | length')
+    local scope_count
+    scope_count=$(echo "$scopes_info" | jq '.scopes | length')
     if [[ "$scope_count" -gt 0 ]]; then
         echo ""
         echo -e "${CYAN}▸ Scopes Detected ($scope_count)${NC}"
@@ -236,9 +273,13 @@ print_compact_summary() {
     local project_info="$1"
     local scopes_info="$2"
 
-    local lang=$(echo "$project_info" | jq -r '.language')
-    local ptype=$(echo "$project_info" | jq -r '.type')
-    local scope_count=$(echo "$scopes_info" | jq '.scopes | length')
+    local lang
+
+    lang=$(echo "$project_info" | jq -r '.language')
+    local ptype
+    ptype=$(echo "$project_info" | jq -r '.type')
+    local scope_count
+    scope_count=$(echo "$scopes_info" | jq '.scopes | length')
 
     echo "Detected: $lang ($ptype), $((scope_count + 1)) AGENTS.md file(s) to generate"
 }

--- a/skills/agent-rules/scripts/verify-commands.sh
+++ b/skills/agent-rules/scripts/verify-commands.sh
@@ -245,6 +245,7 @@ write_json_results() {
 # Look for patterns like: `command arg` or | command | or | `command` |
 extract_commands() {
     # Extract from tables with backticks (| `command` | format)
+    # shellcheck disable=SC2016  # grep/sed pattern: backticks are literal.
     grep -oE '\| `[^`]+`' "$AGENTS_FILE" 2>/dev/null | sed 's/| `//;s/`$//' | grep -v '^\s*$' || true
 
     # Extract from tables without backticks in Commands section
@@ -260,6 +261,7 @@ extract_commands() {
 
     # Extract from inline code that looks like commands
     # Includes: npm, yarn, pnpm, bun, make, go, composer, cargo, python, pip, poetry, uv, deno, gradle, php, vendor/bin
+    # shellcheck disable=SC2016  # grep/sed pattern: backticks are literal.
     grep -oE '`(npm |yarn |pnpm |bun |make |go |composer |cargo |pytest |python |pip |poetry |uv |deno |gradle |php |vendor/bin/)[^`]+`' "$AGENTS_FILE" 2>/dev/null | sed 's/`//g' || true
 }
 


### PR DESCRIPTION
Started as the shellcheck cleanup [#91](https://github.com/netresearch/agent-rules-skill/pull/91) and [#92](https://github.com/netresearch/agent-rules-skill/pull/92) deferred as out of scope. One of the 65 findings turned out to be a real defect.

## The defect

`generate-file-map.sh` decided what a directory holds with nine tests of this shape:

```bash
if ls "$dir"/*.go 2>/dev/null | head -1 > /dev/null; then
```

The file sets `set -euo pipefail`. `head` exits after one line, `ls` dies on the closed pipe with 141, and pipefail makes 141 the pipeline's status — so the `if` reads **false**: "no Go files here", for a directory full of them.

Measured rather than reasoned about — 9000 `*.go` files, 40 runs each in a fresh process:

| | wrong answers |
|---|---|
| `ls … \| head -1` | **40 / 40** |
| `compgen -G` | 0 / 40 |

Not a flaky race. A deterministic failure once the file list exceeds the pipe buffer, which for realistic package directories it does.

**It reached the output, not just an exit code.** End to end on a repository with one large unrecognised directory:

```
before:  widgets/  → project files
after:   widgets/  → Go packages
```

That line ships in a project's AGENTS.md. All nine tests now use `compgen -G`, which globs without a pipe and also handles the non-alphanumeric filenames SC2012 was warning about — so the lint finding and the bug had the same fix.

## The other 64

Genuine false positives, suppressed **where they sit and with a reason**, never blanket-disabled at file scope:

- **11 arrays** in `extract-ci-rules.sh` are read by NAME through `collect_unique`/`arr_to_json`, which take namerefs — shellcheck cannot follow that. One directive per enclosing function (three), not one per declaration (eleven) and not one per file.
- **4 `sed`/`grep` patterns** hold literal backticks, not expansions.
- **1 `source`** cannot be followed because pre-commit runs shellcheck without `-x`, however the path is written.

**31 `local x=$(…)`** in `lib/summary.sh` are split into declaration and assignment. This is not cosmetic: `local` returns its own exit status, so a failing command substitution was silently masked and now surfaces.

## Two findings left standing, deliberately

`BLUE` is unused but belongs to a complete palette with matching colour and no-colour branches; removing one entry invites an inconsistent re-add later. `SUMMARY_SOURCES` is declared, reset and written twice — and read by nothing in this repository. The comment now says that plainly rather than the code merely implying it. Deleting another module's recorded provenance is a behaviour decision for whoever owns it, not part of a lint pass.

## Verification

`shellcheck` over `skills/agent-rules/scripts/` reports **0**, down from 65. All five regression tests pass, `scripts/verify-harness.sh` exits 0, and `validate-skill.sh` reports the same 0 errors / 15 warnings as `main` — checked against `main` rather than assumed, after an earlier count of mine turned out to be from a different context.

## What this does not cover

The `compgen` replacement is proven on `*.go` and by construction identical for the other eight extensions, but only the Go path was exercised end to end. And the SIGPIPE shape was audited in this file only — I did not sweep the rest of the repository for other `… | head` used as a condition.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss)_
