### PR TITLE
chore(release): 3.15.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-rules",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-rules",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, jq 1.7+, git 2.0+."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.15.1"
+  version: "3.15.2"
   repository: https://github.com/netresearch/agent-rules-skill
 allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
 ---


### PR DESCRIPTION
Version bump only; the tag follows once this merges.

Carries one fix: [#95](https://github.com/netresearch/agent-rules-skill/pull/95), where nine directory-content probes used `ls "$dir"/*.ext | head -1` under `set -o pipefail`. `head` exits after one line, `ls` dies on the closed pipe with 141, pipefail makes that the pipeline's status, and the condition reads false — **40 of 40 runs wrong** against 9000 files. Deterministic once the file list exceeds the pipe buffer, not a flaky race.

It reached the output rather than just an exit code: a large package directory was described as `project files` instead of `Go packages` in the generated AGENTS.md. 3.15.1 was tagged before the fix, so the installed version still writes that.

Patch, not minor — one fix, no new capability. Applied with `bump-version.sh` across all three version surfaces, `sync-plugin-manifest.sh`, and `check-version-parity.sh` confirming plugin.json and SKILL.md agree at 3.15.2.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss)_