### PR TITLE
fix(agent-rules): language detection failed on large source trees

### DIFF
--- a/skills/agent-rules/scripts/detect-project.sh
+++ b/skills/agent-rules/scripts/detect-project.sh
@@ -71,15 +71,15 @@ detect_language() {
         fi
 
         # Check for PHP source files (common locations)
-        if [ -d "src" ] && find src -name "*.php" -type f 2>/dev/null | head -1 | grep -q .; then
+        if [ -d "src" ] && [ -n "$(find src -name "*.php" -type f -print -quit 2>/dev/null)" ]; then
             has_php_files=true
-        elif [ -d "Classes" ] && find Classes -name "*.php" -type f 2>/dev/null | head -1 | grep -q .; then
+        elif [ -d "Classes" ] && [ -n "$(find Classes -name "*.php" -type f -print -quit 2>/dev/null)" ]; then
             has_php_files=true
-        elif [ -d "lib" ] && find lib -name "*.php" -type f 2>/dev/null | head -1 | grep -q .; then
+        elif [ -d "lib" ] && [ -n "$(find lib -name "*.php" -type f -print -quit 2>/dev/null)" ]; then
             has_php_files=true
         elif [ -f "ext_emconf.php" ]; then
             has_php_files=true
-        elif find . -maxdepth 2 -name "*.php" -type f 2>/dev/null | head -1 | grep -q .; then
+        elif [ -n "$(find . -maxdepth 2 -name "*.php" -type f -print -quit 2>/dev/null)" ]; then
             has_php_files=true
         fi
 

--- a/skills/agent-rules/scripts/detect-project.sh
+++ b/skills/agent-rules/scripts/detect-project.sh
@@ -71,15 +71,15 @@ detect_language() {
         fi
 
         # Check for PHP source files (common locations)
-        if [ -d "src" ] && [ -n "$(find src -name "*.php" -type f -print -quit 2>/dev/null)" ]; then
+        if [[ -d "src" ]] && [[ -n "$(find src -name "*.php" -type f -print -quit 2>/dev/null)" ]]; then
             has_php_files=true
-        elif [ -d "Classes" ] && [ -n "$(find Classes -name "*.php" -type f -print -quit 2>/dev/null)" ]; then
+        elif [[ -d "Classes" ]] && [[ -n "$(find Classes -name "*.php" -type f -print -quit 2>/dev/null)" ]]; then
             has_php_files=true
-        elif [ -d "lib" ] && [ -n "$(find lib -name "*.php" -type f -print -quit 2>/dev/null)" ]; then
+        elif [[ -d "lib" ]] && [[ -n "$(find lib -name "*.php" -type f -print -quit 2>/dev/null)" ]]; then
             has_php_files=true
         elif [ -f "ext_emconf.php" ]; then
             has_php_files=true
-        elif [ -n "$(find . -maxdepth 2 -name "*.php" -type f -print -quit 2>/dev/null)" ]; then
+        elif [[ -n "$(find . -maxdepth 2 -name "*.php" -type f -print -quit 2>/dev/null)" ]]; then
             has_php_files=true
         fi
 


### PR DESCRIPTION
[#95](https://github.com/netresearch/agent-rules-skill/pull/95) fixed nine of these in `generate-file-map.sh`, and its review stated the rest of the repository had not been swept. It has been now. `detect-project.sh` carried the same defect somewhere it matters more.

## The defect

```bash
if [ -d "src" ] && find src -name "*.php" -type f 2>/dev/null | head -1 | grep -q .
```

`head -1` exits after one line, `find` dies on the closed pipe, and under `set -o pipefail` that becomes the pipeline's status — the condition reads false. 9000 `*.php` files under `src/`, 40 runs in fresh processes: **40 of 40 wrong**.

**This is language detection, not a label.** It selects the template, the scoped files and the commands that follow:

| tree | before | after |
|---|---|---|
| `composer.json` + 9000 PHP files in `src/` | `language = unknown` | `language = php` |
| same shape, 3 PHP files (control) | `language = php` | `language = php` |

The control is what isolates the cause to the file count rather than the fixture — same structure, same `composer.json`, only the number differs, and the number is the pipe-buffer threshold.

Four occurrences replaced with `find … -print -quit`, which stops at the first hit without a pipe.

## The audit that closes the class here

Two other shapes were measured and deliberately left alone:

**`find … | head -5 | wc -l`** (1 site, same file) — not affected. The pipeline's status is discarded; the comparison uses `wc`'s value, which is correct because `head` already handed it the five lines it counts. 20/20 correct in both directions.

**A shell variable piped into `grep -q`** (43 sites) — not affected. The writer is bash's `echo` (42) or `printf` (1) **builtin**, and a builtin absorbs EPIPE without failing the pipeline. Measured at 8 KB, 60 KB and 200 KB with the match at position 0 — the worst case for an early-exiting reader — **0 of 30 wrong** at every size. An external `/usr/bin/printf` in the same shape *does* fail; there are none in this repository.

That last one corrects an assumption I brought into the sweep. I expected `echo … | grep -q` to be the dangerous form and would have rewritten 43 call sites on that belief. The builtin is what saves it, and only the measurement said so.

## Verification

`shellcheck` clean, all five regression tests pass, `scripts/verify-harness.sh` exits 0. The end-to-end check runs `detect-project.sh` itself rather than the shell snippet in isolation, after an earlier probe in this area exercised a name-based rule instead of the code path being changed and therefore proved nothing.

## Not covered

The sweep is this repository only. The same `… | head -1 | grep -q` shape may exist in sibling skill repos; I did not look outside `agent-rules-skill`.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss)_
