### PR TITLE
chore(release): 3.15.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-rules",
-  "version": "3.15.2",
+  "version": "3.15.3",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-rules",
-  "version": "3.15.2",
+  "version": "3.15.3",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, jq 1.7+, git 2.0+."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.15.2"
+  version: "3.15.3"
   repository: https://github.com/netresearch/agent-rules-skill
 allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
 ---


### PR DESCRIPTION
Version bump only; the tag follows the merge.

Carries [#97](https://github.com/netresearch/agent-rules-skill/pull/97). Four `find … | head -1 | grep -q .` conditions in `detect-project.sh` reported false for a directory full of matches — `head` exits after one line, the writer takes SIGPIPE, and `set -o pipefail` makes that the pipeline's status. **40 of 40 runs wrong** at 9000 files.

This one reaches further than the probe released in 3.15.2: it is *language detection*. A PHP project with a `composer.json` and 9000 classes came back as `language = unknown`, and language selects the template, the scoped files and the commands the generated AGENTS.md documents. A three-file control tree in the same shape reported `php`, which pins the cause to the file count rather than the fixture.

3.15.2 was tagged before the fix, so the installed version still does this.

Patch — one fix plus the `[[` conversion SonarCloud required for it, no new capability. Applied with `bump-version.sh` across all three version surfaces, `sync-plugin-manifest.sh`, and `check-version-parity.sh` confirming 3.15.3.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss)_