### PR TITLE
feat(agent-rules): emit a JSON write manifest from generate-agents.sh

### DIFF
--- a/skills/agent-rules/references/scripts-guide.md
+++ b/skills/agent-rules/references/scripts-guide.md
@@ -10,13 +10,43 @@ scripts/generate-agents.sh /path/to/project
 
 Options:
 - `--dry-run` - Preview changes without writing files
+- `--json` - Emit the write manifest as JSON instead of prose (see below)
 - `--verbose` - Show detailed output
 - `--style=thin` - Use thin root template (~30 lines, default)
 - `--style=verbose` - Use verbose root template (~100-200 lines)
 - `--update` - Update existing files only (preserves human edits outside generated markers)
-- `--claude-shim` - Generate CLAUDE.md that imports AGENTS.md (root only, use `--symlinks` instead)
-- `--symlinks` - Create CLAUDE.md and GEMINI.md symlinks at every level (root + subdirectories). Enables Claude Code on-demand loading and Gemini CLI native loading. **Recommended** for cross-agent compatibility.
-- `--force` - Regenerate even if files exist
+- `--claude-shim` - Generate CLAUDE.md that imports AGENTS.md (root only, legacy)
+- `--no-symlinks` - Do not create CLAUDE.md/GEMINI.md at any level. They are created by default at every level where an AGENTS.md is generated, which is what enables Claude Code on-demand loading and Gemini CLI native loading.
+- `--force` - Replace existing CLAUDE.md/GEMINI.md files that are not ours
+
+### Write manifest (`--json`)
+
+One entry per path the run touches, following the `schema: 1` shape the verifier
+scripts use. With `--dry-run` it is a plan of what would be written; without it, a
+receipt of what was. Paths are relative to the project root.
+
+```bash
+scripts/generate-agents.sh /path/to/project --dry-run --json
+```
+
+```json
+{
+  "script": "generate-agents",
+  "schema": 1,
+  "dry_run": true,
+  "project": "/path/to/project",
+  "summary": { "write": 1, "symlink": 1, "keep": 1 },
+  "operations": [
+    { "op": "write",   "kind": "agents-file", "path": "AGENTS.md" },
+    { "op": "symlink", "kind": "compat-file", "path": "CLAUDE.md", "target": "AGENTS.md" },
+    { "op": "keep",    "kind": "compat-file", "path": "GEMINI.md", "reason": "regular file" }
+  ]
+}
+```
+
+`op` is `write`, `symlink` or `keep`; `keep` means an existing file was left alone
+and carries the reason. Human output is suppressed under `--json`, so stdout is
+parseable on its own.
 
 ## Validating Structure
 

--- a/skills/agent-rules/scripts/generate-agents.sh
+++ b/skills/agent-rules/scripts/generate-agents.sh
@@ -33,6 +33,7 @@ FORCE=false
 VERBOSE=false
 CLAUDE_SHIM=false
 CREATE_SYMLINKS=true
+JSON=false
 
 # Parse flags
 while [[ $# -gt 0 ]]; do
@@ -43,6 +44,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --dry-run)
             DRY_RUN=true
+            shift
+            ;;
+        --json)
+            JSON=true
             shift
             ;;
         --update)
@@ -74,6 +79,7 @@ Generate AGENTS.md files for a project following the public agents.md convention
 Options:
   --style=thin|verbose    Template style (default: thin)
   --dry-run               Preview what will be created
+  --json                  Emit the write manifest as JSON (human output suppressed)
   --update                Update existing files only
   --force                 Force regeneration of existing files
   --claude-shim           Generate CLAUDE.md that imports AGENTS.md (root only, legacy)
@@ -84,6 +90,7 @@ Options:
 Examples:
   generate-agents.sh .                    # Generate thin root + scoped files
   generate-agents.sh . --dry-run          # Preview changes
+  generate-agents.sh . --dry-run --json   # Machine-readable plan, nothing written
   generate-agents.sh . --style=verbose    # Use verbose root template
   generate-agents.sh . --update           # Update existing files
   generate-agents.sh . --no-symlinks      # Skip CLAUDE.md/GEMINI.md symlinks
@@ -107,6 +114,31 @@ fi
 # Convert to absolute path before cd (so subsequent script calls work)
 PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
 cd "$PROJECT_DIR"
+
+# --json emits the write manifest instead of the prose, the same way the
+# read-only scripts do it: stdout is parked on fd 3 and the human lines go
+# nowhere, so every existing echo stays untouched.
+if [ "$JSON" = true ]; then
+    exec 3>&1 1>/dev/null
+fi
+
+# One entry per path the run touches. With --dry-run it is a plan, without it a
+# receipt of what was written -- the dry_run field in the output says which.
+MANIFEST=()
+# emit_op OP KIND PATH [KEY VALUE]
+#   op:   write | symlink | keep
+#   kind: agents-file | compat-file | shim
+# Paths are recorded relative to the project root, so a manifest can be
+# reviewed and compared without carrying one machine's directory layout.
+emit_op() {
+    local op="$1" kind="$2" path="$3" key="${4:-}" value="${5:-}"
+    local rel="${path#"$PROJECT_DIR"/}"
+    MANIFEST+=("$(jq -nc \
+        --arg op "$op" --arg kind "$kind" --arg path "$rel" \
+        --arg key "$key" --arg value "$value" \
+        '{op: $op, kind: $kind, path: $path}
+         + (if $key == "" then {} else {($key): $value} end)')")
+}
 
 # Initialize summary tracking
 init_summary
@@ -143,6 +175,7 @@ report_kept_file() {
     else
         what="regular file"
     fi
+    emit_op keep compat-file "$file" reason "$what"
     echo "⏭️  Kept: $label ($what) — use --force to replace"
 }
 
@@ -788,6 +821,7 @@ ROOT_FILE="$PROJECT_DIR/AGENTS.md"
 if [ -f "$ROOT_FILE" ] && [ "$FORCE" = false ] && [ "$UPDATE_ONLY" = false ]; then
     log "Root AGENTS.md already exists, skipping (use --force to regenerate)"
 elif [ "$DRY_RUN" = true ]; then
+    emit_op write agents-file "$ROOT_FILE"
     echo "[DRY-RUN] Would create/update: $ROOT_FILE"
 else
     log "Generating root AGENTS.md..."
@@ -1266,6 +1300,7 @@ print(f\"Processing {item}\")  # Use logging module
     if [ "$UPDATE_ONLY" = true ]; then
         echo "✅ Updated: $ROOT_FILE"
     else
+        emit_op write agents-file "$ROOT_FILE"
         echo "✅ Created: $ROOT_FILE"
     fi
 fi
@@ -1276,6 +1311,7 @@ if [ "$CLAUDE_SHIM" = true ]; then
     if [ -f "$CLAUDE_FILE" ] && [ "$FORCE" = false ]; then
         log "CLAUDE.md already exists, skipping (use --force to regenerate)"
     elif [ "$DRY_RUN" = true ]; then
+        emit_op write shim "$CLAUDE_FILE"
         echo "[DRY-RUN] Would create: $CLAUDE_FILE"
     else
         cat > "$CLAUDE_FILE" << 'CLAUDESHIM'
@@ -1287,6 +1323,7 @@ if [ "$CLAUDE_SHIM" = true ]; then
 
 <!-- Add Claude-specific overrides below if needed -->
 CLAUDESHIM
+        emit_op write shim "$CLAUDE_FILE"
         echo "✅ Created: $CLAUDE_FILE (shim importing AGENTS.md)"
     fi
 fi
@@ -1300,17 +1337,21 @@ if [ "$CREATE_SYMLINKS" = true ] && [ "$CLAUDE_SHIM" = false ]; then
         SYMLINK_FILE="$PROJECT_DIR/$symlink_name"
         if compat_file_is_ours "$SYMLINK_FILE"; then
             if [ "$DRY_RUN" = true ]; then
+                emit_op symlink compat-file "$SYMLINK_FILE" target AGENTS.md
                 echo "[DRY-RUN] Would symlink: $SYMLINK_FILE → AGENTS.md"
             else
                 ln -sf AGENTS.md "$SYMLINK_FILE"
+                emit_op symlink compat-file "$SYMLINK_FILE" target AGENTS.md
                 echo "✅ Symlinked: $SYMLINK_FILE → AGENTS.md"
             fi
         elif [ "$FORCE" = true ]; then
             if [ "$DRY_RUN" = true ]; then
+                emit_op symlink compat-file "$SYMLINK_FILE" target AGENTS.md
                 echo "[DRY-RUN] Would replace: $SYMLINK_FILE → AGENTS.md (--force)"
             else
                 rm -f "$SYMLINK_FILE"
                 ln -s AGENTS.md "$SYMLINK_FILE"
+                emit_op symlink compat-file "$SYMLINK_FILE" target AGENTS.md
                 echo "✅ Replaced: $SYMLINK_FILE → AGENTS.md (--force)"
             fi
         else
@@ -1338,6 +1379,7 @@ else
         fi
 
         if [ "$DRY_RUN" = true ]; then
+            emit_op write agents-file "$SCOPE_FILE"
             echo "[DRY-RUN] Would create/update: $SCOPE_FILE"
             continue
         fi
@@ -2307,6 +2349,7 @@ else
         if [ "$UPDATE_ONLY" = true ]; then
             echo "✅ Updated: $SCOPE_FILE"
         else
+            emit_op write agents-file "$SCOPE_FILE"
             echo "✅ Created: $SCOPE_FILE"
         fi
 
@@ -2324,29 +2367,35 @@ else
                         continue
                     fi
                     if [ "$DRY_RUN" = true ]; then
+                        emit_op write compat-file "$SYMLINK_FILE" note "@AGENTS.md import file"
                         echo "[DRY-RUN] Would write import file: $SYMLINK_FILE (@AGENTS.md)"
                     else
                         rm -f "$SYMLINK_FILE"
                         printf '%s\n\n%s\n' \
                             '<!-- Regular file, not a symlink: the TYPO3 docs renderer (Flysystem) rejects symbolic links inside Documentation/. -->' \
                             '@AGENTS.md' > "$SYMLINK_FILE"
+                        emit_op write compat-file "$SYMLINK_FILE" note "@AGENTS.md import file"
                         echo "   ↳ Import file: $SCOPE_PATH/$symlink_name (@AGENTS.md, symlink-hostile directory)"
                     fi
                     continue
                 fi
                 if compat_file_is_ours "$SYMLINK_FILE"; then
                     if [ "$DRY_RUN" = true ]; then
+                        emit_op symlink compat-file "$SYMLINK_FILE" target AGENTS.md
                         echo "[DRY-RUN] Would symlink: $SYMLINK_FILE → AGENTS.md"
                     else
                         ln -sf AGENTS.md "$SYMLINK_FILE"
+                        emit_op symlink compat-file "$SYMLINK_FILE" target AGENTS.md
                         echo "   ↳ Symlinked: $SCOPE_PATH/$symlink_name → AGENTS.md"
                     fi
                 elif [ "$FORCE" = true ]; then
                     if [ "$DRY_RUN" = true ]; then
+                        emit_op symlink compat-file "$SYMLINK_FILE" target AGENTS.md
                         echo "[DRY-RUN] Would replace: $SYMLINK_FILE → AGENTS.md (--force)"
                     else
                         rm -f "$SYMLINK_FILE"
                         ln -s AGENTS.md "$SYMLINK_FILE"
+                        emit_op symlink compat-file "$SYMLINK_FILE" target AGENTS.md
                         echo "   ↳ Replaced: $SCOPE_PATH/$symlink_name → AGENTS.md (--force)"
                     fi
                 else
@@ -2374,3 +2423,18 @@ fi
 echo ""
 echo "✅ AGENTS.md generation complete!"
 [ "$SCOPE_COUNT" -gt 0 ] && echo "   Generated: 1 root + $SCOPE_COUNT scoped files" || true
+
+# The manifest goes to the real stdout (fd 3), which --json parked before any
+# human line was written. dry_run tells a reader whether these operations are
+# planned or already carried out.
+if [ "$JSON" = true ]; then
+    printf '%s\n' "${MANIFEST[@]:-}" \
+        | jq -s --arg project "$PROJECT_DIR" --argjson dry "$([ "$DRY_RUN" = true ] && echo true || echo false)" \
+            'map(select(. != null)) as $ops
+             | {script: "generate-agents",
+                schema: 1,
+                dry_run: $dry,
+                project: $project,
+                summary: ($ops | group_by(.op) | map({key: .[0].op, value: length}) | from_entries),
+                operations: $ops}' >&3
+fi

--- a/skills/agent-rules/scripts/generate-agents.sh
+++ b/skills/agent-rules/scripts/generate-agents.sh
@@ -819,6 +819,7 @@ build_workflow_info() {
 ROOT_FILE="$PROJECT_DIR/AGENTS.md"
 
 if [ -f "$ROOT_FILE" ] && [ "$FORCE" = false ] && [ "$UPDATE_ONLY" = false ]; then
+    emit_op keep agents-file "$ROOT_FILE" reason "already exists"
     log "Root AGENTS.md already exists, skipping (use --force to regenerate)"
 elif [ "$DRY_RUN" = true ]; then
     emit_op write agents-file "$ROOT_FILE"
@@ -1298,6 +1299,7 @@ print(f\"Processing {item}\")  # Use logging module
     enforce_byte_budget "$ROOT_FILE" "$BYTE_BUDGET"
 
     if [ "$UPDATE_ONLY" = true ]; then
+        emit_op write agents-file "$ROOT_FILE"
         echo "✅ Updated: $ROOT_FILE"
     else
         emit_op write agents-file "$ROOT_FILE"
@@ -1309,6 +1311,7 @@ fi
 if [ "$CLAUDE_SHIM" = true ]; then
     CLAUDE_FILE="$PROJECT_DIR/CLAUDE.md"
     if [ -f "$CLAUDE_FILE" ] && [ "$FORCE" = false ]; then
+        emit_op keep shim "$CLAUDE_FILE" reason "already exists"
         log "CLAUDE.md already exists, skipping (use --force to regenerate)"
     elif [ "$DRY_RUN" = true ]; then
         emit_op write shim "$CLAUDE_FILE"
@@ -1374,6 +1377,7 @@ else
         SCOPE_FILE="$PROJECT_DIR/$SCOPE_PATH/AGENTS.md"
 
         if [ -f "$SCOPE_FILE" ] && [ "$FORCE" = false ] && [ "$UPDATE_ONLY" = false ]; then
+            emit_op keep agents-file "$SCOPE_FILE" reason "already exists"
             log "Scoped AGENTS.md already exists: $SCOPE_PATH, skipping"
             continue
         fi
@@ -2347,6 +2351,7 @@ else
         enforce_byte_budget "$SCOPE_FILE" "$((BYTE_BUDGET / 2))"
 
         if [ "$UPDATE_ONLY" = true ]; then
+            emit_op write agents-file "$SCOPE_FILE"
             echo "✅ Updated: $SCOPE_FILE"
         else
             emit_op write agents-file "$SCOPE_FILE"

--- a/skills/agent-rules/scripts/tests/test-json-manifest.sh
+++ b/skills/agent-rules/scripts/tests/test-json-manifest.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Test for the generate-agents.sh write manifest (issue #107).
+#
+# generate-agents.sh is the only script in the skill that writes, and was the
+# only one without --json. The manifest lists one entry per path the run
+# touches, so a caller can review exactly what would change (--dry-run) or what
+# did change (without it) instead of parsing nine different prose lines.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(dirname "$SCRIPT_DIR")"
+GENERATE="$SCRIPTS_DIR/generate-agents.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "❌ FAIL: $1"; exit 1; }
+pass() { echo "✅ PASS: $1"; }
+
+make_fixture() {
+    local fx="$1"
+    mkdir -p "$fx/src"
+    cat > "$fx/package.json" <<'JSON'
+{ "name": "fixture", "version": "1.0.0", "scripts": { "test": "echo t" } }
+JSON
+    for i in 1 2 3 4 5 6; do printf 'export const c%s = %s\n' "$i" "$i" > "$fx/src/c$i.js"; done
+    git -C "$fx" init -q
+    git -C "$fx" -c user.email=t@t.t -c user.name=t add -A
+    git -C "$fx" -c user.email=t@t.t -c user.name=t commit -qm init
+}
+
+# --- Test 1: --dry-run --json is valid JSON, carries the schema, writes nothing
+FX="$WORK/plan"
+make_fixture "$FX"
+printf '# my own rules\n' > "$FX/GEMINI.md"
+OUT="$(bash "$GENERATE" "$FX" --dry-run --json 2>/dev/null)" || fail "generate-agents.sh errored"
+jq -e . >/dev/null 2>&1 <<<"$OUT" || fail "output is not valid JSON: $OUT"
+[ "$(jq -r '.script' <<<"$OUT")" = "generate-agents" ] || fail "wrong script field"
+[ "$(jq -r '.schema' <<<"$OUT")" = "1" ] || fail "wrong schema field"
+[ "$(jq -r '.dry_run' <<<"$OUT")" = "true" ] || fail "dry_run not true under --dry-run"
+[ -e "$FX/AGENTS.md" ] && fail "--dry-run --json wrote AGENTS.md"
+[ -e "$FX/CLAUDE.md" ] && fail "--dry-run --json created a symlink"
+pass "--dry-run --json emits a valid manifest and writes nothing"
+
+# --- Test 2: human output is suppressed, so stdout is parseable
+grep -q '✅' <<<"$OUT" && fail "human output leaked into the JSON stream"
+pass "--json suppresses the prose output"
+
+# --- Test 3: every operation kind appears, with the fields it needs
+[ "$(jq -r '[.operations[] | select(.op=="write" and .path=="AGENTS.md")] | length' <<<"$OUT")" = "1" ] \
+    || fail "root AGENTS.md missing from the manifest"
+[ "$(jq -r '.operations[] | select(.path=="CLAUDE.md") | .target' <<<"$OUT")" = "AGENTS.md" ] \
+    || fail "symlink entry has no target"
+[ "$(jq -r '.operations[] | select(.path=="GEMINI.md") | .op' <<<"$OUT")" = "keep" ] \
+    || fail "the kept regular file is not recorded as keep"
+jq -e '.operations[] | select(.path=="GEMINI.md") | .reason' >/dev/null <<<"$OUT" \
+    || fail "keep entry carries no reason"
+pass "write, symlink and keep entries carry their fields"
+
+# --- Test 4: paths are relative to the project root, never absolute
+jq -e '[.operations[].path | select(startswith("/"))] | length == 0' >/dev/null <<<"$OUT" \
+    || fail "manifest contains absolute paths"
+pass "paths are relative to the project root"
+
+# --- Test 5: the summary counts what the operations list holds
+for op in write symlink keep; do
+    want="$(jq -r --arg op "$op" '[.operations[] | select(.op==$op)] | length' <<<"$OUT")"
+    got="$(jq -r --arg op "$op" '.summary[$op] // 0' <<<"$OUT")"
+    [ "$want" = "$got" ] || fail "summary.$op says $got, operations hold $want"
+done
+pass "summary matches the operations list"
+
+# --- Test 6: without --dry-run the same manifest is a receipt of real writes
+FX="$WORK/receipt"
+make_fixture "$FX"
+OUT="$(bash "$GENERATE" "$FX" --json 2>/dev/null)" || fail "generate-agents.sh errored"
+[ "$(jq -r '.dry_run' <<<"$OUT")" = "false" ] || fail "dry_run not false on a real run"
+[ -f "$FX/AGENTS.md" ] || fail "real run wrote no AGENTS.md"
+while read -r p; do
+    [ -e "$FX/$p" ] || fail "manifest claims $p but it does not exist"
+done < <(jq -r '.operations[] | select(.op!="keep") | .path' <<<"$OUT")
+pass "every non-keep path in the receipt exists on disk"
+
+# --- Test 7: the prose output still works without --json (companion)
+FX="$WORK/prose"
+make_fixture "$FX"
+OUT="$(bash "$GENERATE" "$FX" --dry-run 2>/dev/null)" || fail "generate-agents.sh errored"
+grep -q 'DRY-RUN' <<<"$OUT" || fail "prose output lost its DRY-RUN lines"
+jq -e . >/dev/null 2>&1 <<<"$OUT" && fail "prose run emitted JSON"
+pass "the default output is unchanged"
+
+echo ""
+echo "All JSON manifest tests passed."

--- a/skills/agent-rules/scripts/tests/test-json-manifest.sh
+++ b/skills/agent-rules/scripts/tests/test-json-manifest.sh
@@ -89,5 +89,24 @@ grep -q 'DRY-RUN' <<<"$OUT" || fail "prose output lost its DRY-RUN lines"
 jq -e . >/dev/null 2>&1 <<<"$OUT" && fail "prose run emitted JSON"
 pass "the default output is unchanged"
 
+# --- Test 8: a file left alone is recorded, not merely absent from the list
+# Without this, a consumer cannot tell "AGENTS.md was skipped because it exists"
+# from "AGENTS.md was never considered" — both look like a missing entry.
+FX="$WORK/second-run"
+make_fixture "$FX"
+bash "$GENERATE" "$FX" >/dev/null 2>&1 || fail "generate-agents.sh errored"
+OUT="$(bash "$GENERATE" "$FX" --dry-run --json 2>/dev/null)" || fail "generate-agents.sh errored"
+[ "$(jq -r '.operations[] | select(.path=="AGENTS.md") | .op' <<<"$OUT")" = "keep" ] \
+    || fail "an existing AGENTS.md is not recorded as keep on a second run"
+[ "$(jq -r '.operations[] | select(.path=="AGENTS.md") | .reason' <<<"$OUT")" = "already exists" ] \
+    || fail "the keep entry for AGENTS.md carries no reason"
+pass "an existing AGENTS.md is recorded as keep, with its reason"
+
+# --- Test 9: --update writes, and the manifest says so
+OUT="$(bash "$GENERATE" "$FX" --update --json 2>/dev/null)" || fail "generate-agents.sh errored"
+[ "$(jq -r '.operations[] | select(.path=="AGENTS.md") | .op' <<<"$OUT")" = "write" ] \
+    || fail "--update rewrote AGENTS.md without recording it as a write"
+pass "--update records the rewrite it performs"
+
 echo ""
 echo "All JSON manifest tests passed."


### PR DESCRIPTION
Closes #107, which was question 6 of #94: a machine-readable write manifest.

`generate-agents.sh` is the only script in the skill that writes and was the only one without `--json` — the five read-only scripts already emit `{script, schema:1, summary, …}`. Its `--dry-run` produced prose across nine different lines (`✅ Created:`, `[DRY-RUN] Would symlink:`, `⏭️  Kept:`, `↳ Import file:`), so anything downstream had to parse them.

`--json` now emits one entry per path the run touches, in the same schema. With `--dry-run` it is a plan; without it, a receipt — the `dry_run` field says which, so the same flag answers both "what would this write" and "what did it write". Paths are relative to the project root, so a manifest is reviewable rather than machine-specific.

```json
{
  "script": "generate-agents",
  "schema": 1,
  "dry_run": true,
  "project": "/path/to/project",
  "summary": { "write": 1, "symlink": 1, "keep": 1 },
  "operations": [
    { "op": "write",   "kind": "agents-file", "path": "AGENTS.md" },
    { "op": "symlink", "kind": "compat-file", "path": "CLAUDE.md", "target": "AGENTS.md" },
    { "op": "keep",    "kind": "compat-file", "path": "GEMINI.md", "reason": "regular file" }
  ]
}
```

The prose output is untouched. `--json` parks stdout on fd 3 the way `validate-structure.sh` does, so every existing `echo` stays exactly as it was and only the stream changes.

## Also in here

While documenting the flag, `scripts-guide.md` turned out to list a `--symlinks` option the parser has never had. Passing it fails with `Project directory not found: --symlinks`, because an unknown argument is taken for the project path. Same family as #102. The option list now names `--no-symlinks`, which is the flag that actually exists, and `--json`.

## Verification

```
8/8 script tests pass (7 pre-existing + the new manifest test)
shellcheck clean across scripts/, scripts/lib/, scripts/tests/
pre-commit run --files <changed>: all hooks pass
```

The new test asserts valid JSON and the schema fields, that `--dry-run --json` writes nothing, that no absolute paths leak into the manifest, that `summary` agrees with `operations` rather than being counted separately, and that every non-`keep` path in a receipt exists on disk afterwards. It carries a companion case proving the default prose output is unchanged, so it cannot pass by breaking the normal path.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01JYQciiXoiApXBfcJrFMnA9)_
