### PR TITLE
refactor(agent-rules): declare the shipped scripts in allowed-tools, not bash

### DIFF
--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   author: Netresearch DTT GmbH
   version: "3.15.3"
   repository: https://github.com/netresearch/agent-rules-skill
-allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
+allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*) Bash(bash ${CLAUDE_SKILL_DIR}/scripts/*) Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Read Glob Grep
 ---
 
 # AGENTS.md Generator Skill
@@ -24,21 +24,23 @@ Generate and maintain AGENTS.md files following the [agents.md convention](https
 
 ## Scripts
 
+Call every script by its full path: `bash ${CLAUDE_SKILL_DIR}/scripts/<name> PATH`. A relative `scripts/…` is not covered by the frontmatter rule and raises a permission prompt per call.
+
 | Script | Purpose |
 |--------|---------|
-| `scripts/generate-agents.sh PATH` | Generate AGENTS.md files |
-| `scripts/validate-structure.sh PATH` | Validate structure compliance |
-| `scripts/check-freshness.sh PATH` | Check if files are outdated |
-| `scripts/verify-content.sh PATH` | Verify documented files/commands match codebase |
-| `scripts/verify-commands.sh PATH` | Verify documented commands execute |
-| `scripts/score-agents.sh PATH` | Grade AGENTS.md quality, worst-first |
-| `scripts/detect-project.sh PATH` | Detect language, version, build tools |
-| `scripts/detect-scopes.sh PATH` | Identify directories needing scoped files |
-| `scripts/extract-commands.sh PATH` | Extract commands from build configs |
-| `scripts/extract-ci-rules.sh PATH` | Extract CI quality gates and version matrix |
-| `scripts/extract-architecture-rules.sh PATH` | Extract module boundaries |
-| `scripts/extract-adrs.sh PATH` | Extract architectural decision records |
-| `scripts/extract-github-rulesets.sh PATH` | Extract GitHub rulesets and merge rules |
+| `generate-agents.sh PATH` | Generate AGENTS.md files |
+| `validate-structure.sh PATH` | Validate structure compliance |
+| `check-freshness.sh PATH` | Check if files are outdated |
+| `verify-content.sh PATH` | Verify documented files/commands match codebase |
+| `verify-commands.sh PATH` | Verify documented commands execute |
+| `score-agents.sh PATH` | Grade AGENTS.md quality, worst-first |
+| `detect-project.sh PATH` | Detect language, version, build tools |
+| `detect-scopes.sh PATH` | Identify directories needing scoped files |
+| `extract-commands.sh PATH` | Extract commands from build configs |
+| `extract-ci-rules.sh PATH` | Extract CI quality gates and version matrix |
+| `extract-architecture-rules.sh PATH` | Extract module boundaries |
+| `extract-adrs.sh PATH` | Extract architectural decision records |
+| `extract-github-rulesets.sh PATH` | Extract GitHub rulesets and merge rules |
 
 See `references/scripts-guide.md` for full options.
 

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -24,7 +24,7 @@ Generate and maintain AGENTS.md files following the [agents.md convention](https
 
 ## Scripts
 
-Call every script by its full path: `bash ${CLAUDE_SKILL_DIR}/scripts/<name> PATH`. A relative `scripts/…` is not covered by the frontmatter rule and raises a permission prompt per call.
+Call every script by its full path: `bash ${CLAUDE_SKILL_DIR}/scripts/<name> PATH`. Calling one relative to the working directory is not covered by the frontmatter rule and raises a permission prompt per call.
 
 | Script | Purpose |
 |--------|---------|

--- a/skills/agent-rules/references/ai-tool-compatibility.md
+++ b/skills/agent-rules/references/ai-tool-compatibility.md
@@ -215,8 +215,8 @@ level where an AGENTS.md is generated. `--no-symlinks` turns that off; there is 
 detection that overrides the flag.
 
 ```bash
-scripts/generate-agents.sh /path/to/project              # Symlinks created by default
-scripts/generate-agents.sh /path/to/project --no-symlinks # No CLAUDE.md/GEMINI.md at any level
+bash ${CLAUDE_SKILL_DIR}/scripts/generate-agents.sh /path/to/project              # Symlinks created by default
+bash ${CLAUDE_SKILL_DIR}/scripts/generate-agents.sh /path/to/project --no-symlinks # No CLAUDE.md/GEMINI.md at any level
 ```
 
 The `--claude-shim` flag creates a root-only CLAUDE.md with `@import` (legacy behavior).

--- a/skills/agent-rules/references/output-structure.md
+++ b/skills/agent-rules/references/output-structure.md
@@ -76,7 +76,7 @@ When updating existing AGENTS.md files, preserve custom content:
 
 **1. Use `--update` flag:**
 ```bash
-scripts/generate-agents.sh /path/to/project --update
+bash ${CLAUDE_SKILL_DIR}/scripts/generate-agents.sh /path/to/project --update
 ```
 This preserves content outside `<!-- GENERATED:START -->` / `<!-- GENERATED:END -->` markers.
 

--- a/skills/agent-rules/references/quality-rubric.md
+++ b/skills/agent-rules/references/quality-rubric.md
@@ -3,7 +3,7 @@
 Grade AGENTS.md files so you know which ones most need work. The grade has two
 layers that are **kept separate on purpose**:
 
-1. **Deterministic score** — `scripts/score-agents.sh PATH`. A 0-100 from the four
+1. **Deterministic score** — `${CLAUDE_SKILL_DIR}/scripts/score-agents.sh PATH`. A 0-100 from the four
    verifier scripts; no model call, so re-running on an unchanged tree gives the
    same grade — except a file dated *today*, where git's bare-date `--since` can
    shift the Currency axis within the day.
@@ -50,7 +50,7 @@ cat > /tmp/review.json <<'JSON'
   "web/AGENTS.md": {"architecture":"weak","actionability":"weak","non_obvious":"weak"}
 }
 JSON
-scripts/score-agents.sh PATH --review /tmp/review.json
+bash ${CLAUDE_SKILL_DIR}/scripts/score-agents.sh PATH --review /tmp/review.json
 ```
 
 ```
@@ -72,7 +72,7 @@ the overlay never moves the reproducible number.
 
 ## Workflow
 
-1. `scripts/score-agents.sh PATH` → deterministic report (worst-first).
+1. `${CLAUDE_SKILL_DIR}/scripts/score-agents.sh PATH` → deterministic report (worst-first).
 2. Open the worst-graded files; run the three overlay axes on each.
 3. Fix highest-leverage gaps first (a `D` on Structure is mechanical; a `weak`
    on Non-obvious patterns needs human/session knowledge — see

--- a/skills/agent-rules/references/scripts-guide.md
+++ b/skills/agent-rules/references/scripts-guide.md
@@ -5,7 +5,7 @@ Complete reference for all AGENTS.md generator scripts.
 ## Generating AGENTS.md Files
 
 ```bash
-scripts/generate-agents.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/generate-agents.sh /path/to/project
 ```
 
 Options:
@@ -26,7 +26,7 @@ scripts use. With `--dry-run` it is a plan of what would be written; without it,
 receipt of what was. Paths are relative to the project root.
 
 ```bash
-scripts/generate-agents.sh /path/to/project --dry-run --json
+bash ${CLAUDE_SKILL_DIR}/scripts/generate-agents.sh /path/to/project --dry-run --json
 ```
 
 ```json
@@ -51,7 +51,7 @@ parseable on its own.
 ## Validating Structure
 
 ```bash
-scripts/validate-structure.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/validate-structure.sh /path/to/project
 ```
 
 Options:
@@ -61,7 +61,7 @@ Options:
 ## Checking Freshness
 
 ```bash
-scripts/check-freshness.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/check-freshness.sh /path/to/project
 ```
 
 This script:
@@ -75,13 +75,13 @@ Options:
 
 Example with full validation:
 ```bash
-scripts/validate-structure.sh /path/to/project --check-freshness --verbose
+bash ${CLAUDE_SKILL_DIR}/scripts/validate-structure.sh /path/to/project --check-freshness --verbose
 ```
 
 ## Detecting Project Type
 
 ```bash
-scripts/detect-project.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/detect-project.sh /path/to/project
 ```
 
 Detects project language, version, and build tools.
@@ -89,7 +89,7 @@ Detects project language, version, and build tools.
 ## Detecting Scopes
 
 ```bash
-scripts/detect-scopes.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/detect-scopes.sh /path/to/project
 ```
 
 Identifies directories that should have scoped AGENTS.md files.
@@ -97,7 +97,7 @@ Identifies directories that should have scoped AGENTS.md files.
 ## Extracting Commands
 
 ```bash
-scripts/extract-commands.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/extract-commands.sh /path/to/project
 ```
 
 Extracts build commands from Makefile, package.json, composer.json, or go.mod.
@@ -105,7 +105,7 @@ Extracts build commands from Makefile, package.json, composer.json, or go.mod.
 ## Extracting Documentation
 
 ```bash
-scripts/extract-documentation.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/extract-documentation.sh /path/to/project
 ```
 
 Extracts information from README.md, CONTRIBUTING.md, SECURITY.md, and other documentation.
@@ -113,7 +113,7 @@ Extracts information from README.md, CONTRIBUTING.md, SECURITY.md, and other doc
 ## Extracting Platform Files
 
 ```bash
-scripts/extract-platform-files.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/extract-platform-files.sh /path/to/project
 ```
 
 Extracts information from .github/, .gitlab/, CODEOWNERS, dependabot.yml, etc.
@@ -121,7 +121,7 @@ Extracts information from .github/, .gitlab/, CODEOWNERS, dependabot.yml, etc.
 ## Extracting IDE Settings
 
 ```bash
-scripts/extract-ide-settings.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/extract-ide-settings.sh /path/to/project
 ```
 
 Extracts information from .editorconfig, .vscode/, .idea/, etc.
@@ -129,7 +129,7 @@ Extracts information from .editorconfig, .vscode/, .idea/, etc.
 ## Extracting AI Agent Configs
 
 ```bash
-scripts/extract-agent-configs.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/extract-agent-configs.sh /path/to/project
 ```
 
 Extracts information from .cursor/, .claude/, copilot-instructions.md, etc.
@@ -139,7 +139,7 @@ Extracts information from .cursor/, .claude/, copilot-instructions.md, etc.
 **CRITICAL: Always run this before considering AGENTS.md files complete.**
 
 ```bash
-scripts/verify-content.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/verify-content.sh /path/to/project
 ```
 
 This script:
@@ -160,7 +160,7 @@ Options:
 To prevent "command rot" (documented commands that no longer work):
 
 ```bash
-scripts/verify-commands.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/verify-commands.sh /path/to/project
 ```
 
 This script:
@@ -179,8 +179,8 @@ Options:
 ## Scoring Quality
 
 ```bash
-scripts/score-agents.sh /path/to/project          # human report, worst-first
-scripts/score-agents.sh /path/to/project --json   # machine-readable scoring
+bash ${CLAUDE_SKILL_DIR}/scripts/score-agents.sh /path/to/project          # human report, worst-first
+bash ${CLAUDE_SKILL_DIR}/scripts/score-agents.sh /path/to/project --json   # machine-readable scoring
 ```
 
 Aggregates the `--json` output of the four verifier scripts into a **reproducible**
@@ -205,13 +205,13 @@ number, see [`quality-rubric.md`](quality-rubric.md).
 
 ```bash
 # 1. Run structure validation
-scripts/validate-structure.sh /path/to/project --verbose
+bash ${CLAUDE_SKILL_DIR}/scripts/validate-structure.sh /path/to/project --verbose
 
 # 2. Verify content accuracy
-scripts/verify-content.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/verify-content.sh /path/to/project
 
 # 3. Verify commands work
-scripts/verify-commands.sh /path/to/project
+bash ${CLAUDE_SKILL_DIR}/scripts/verify-commands.sh /path/to/project
 ```
 
 **Validation criteria:**


### PR DESCRIPTION
First application of the rule in netresearch/skill-repo-skill#272 (merged), and the answer to question 4 of #94: narrow the authority the skill asks for.

## Before / after

```yaml
- allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
+ allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*) Bash(bash ${CLAUDE_SKILL_DIR}/scripts/*) Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Read Glob Grep
```

`Bash(bash:*)` pre-approved every bash command the skill issues for the whole turn — which is what an external scanner reads off the manifest. The rule now names the shipped scripts. Claude Code substitutes `${CLAUDE_SKILL_DIR}` in both the skill body and the Bash rules of the frontmatter, so this survives every installation method and version without a pinned path. Both call forms are listed, because a direct call and a `bash <path>` call are different prefixes.

`git`, `jq`, `grep` and `find` stay: the agent runs those itself to verify what it documents, and they are not covered by a scripts pattern.

## The body had to move with it

A rule that does not match the invocation the body documents is worse than the broad one — it produces a prompt per script call, which people click away. So the Scripts table drops its relative `scripts/` prefix and one line above it gives the full-path form, and the four references that showed runnable calls were converted too. An agent that copies a call out of `scripts-guide.md` would otherwise fall outside the rule.

## What this does not buy

`allowed-tools` grants; it does not restrict. Per the documentation, "every tool remains callable, and your permission settings still govern tools that are not listed". This narrows the surface the skill works on *without asking* — not what it can do. Worth stating, because #94 read the field as a capability declaration and it is not one.

## Verification

```
8/8 script tests pass
validate-skill.sh: 0 errors, 15 warnings — identical to the count on main, no new ones
pre-commit run --files <changed>: all hooks pass
```

Not verified end to end: this session runs with permission prompts bypassed, so neither outcome would mean anything here. The check is one pass in default mode with unmodified settings, and review on #272 sharpened what it can conclude: a `permissions.allow` rule or a bypass mode approves the command independently of `allowed-tools`, an `ask` rule outranks it and prompts anyway, a `deny` rule blocks without prompting at all, and a compound command needs every part to match. So a prompt is evidence to investigate, not proof of a mismatch — and its absence is not proof of a match either. I would rather say that than imply a measurement I did not make.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01JYQciiXoiApXBfcJrFMnA9)_

